### PR TITLE
Fix how we process links to index pages in the current dir

### DIFF
--- a/src/_plugins/md-links-to-html-links.rb
+++ b/src/_plugins/md-links-to-html-links.rb
@@ -1,11 +1,16 @@
 module ConvertMdLinksToHtml
     class Generator < Jekyll::Generator
+        LINK_TO_OTHER_DIR_INDEX_RE = /(\[[^\]]*\]\([^:\)]*\/)(index\.md)(#[^\)]*)?\)/
+        LINK_TO_CURRENT_DIR_INDEX_RE = /(\[[^\]]*\]\([^:\)]*)((?<=\()index\.md)(#[^\)]*)?\)/
+        NON_INDEX_LINK_RE = /(\[[^\]]*\]\([^:\)]*)(?<!\/index)(?<!\(index)\.md(#[^\)]*)?\)/
+
         def generate(site)
             site.pages.each { |p| convert_links(site, p) }
         end
         def convert_links(site, page)
-            page.content = page.content.gsub(/(\[[^\]]*\]\([^:\)]*)(index\.md)(#[^\)]*)?\)/, '\1\3)')
-            page.content = page.content.gsub(/(\[[^\]]*\]\([^:\)]*)\.md(#[^\)]*)?\)/, '\1.html\2)')
+            page.content = page.content.gsub(LINK_TO_OTHER_DIR_INDEX_RE, '\1\3)')
+            page.content = page.content.gsub(LINK_TO_CURRENT_DIR_INDEX_RE, '\1.\3)')
+            page.content = page.content.gsub(NON_INDEX_LINK_RE, '\1.html\2)')
         end
     end
 end


### PR DESCRIPTION
While messing with the broken link checker spotted a bug with how we convert links to `index.md` in the current directory.
\cc @DevExpress/testcafe-docs 