### PR TITLE
Begin every page title with the site title

### DIFF
--- a/src/_config.yml
+++ b/src/_config.yml
@@ -1,5 +1,5 @@
 # Site settings
-title: "TestCafe: Web Testing Framework"
+title: "TestCafe: Automated Browser Testing"
 baseurl: "/testcafe" 
 # url: "http://devexpress.github.io" 
   

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <title>{{ site.title }}{% if page.title %} | {{ page.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   <link rel="shortcut icon" href="/testcafe/favicon.ico">


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

Fixes page titles. Each page title should begin with the site title.
Now it's like `TestCafe: Web Testing Framework | {page title}`.

(we will update the site title when we finalize the tagline)